### PR TITLE
Fix autolink plugin for google analytics

### DIFF
--- a/www/_base.mako
+++ b/www/_base.mako
@@ -233,7 +233,7 @@ ${self.body()}
 
   ga('create', 'UA-26813616-1', 'auto', {'allowLinker': true});
   ga('require', 'linker');
-  ga('linker:autoLink', ['openscienceframework.org'] );
+  ga('linker:autoLink', ['openscienceframework.org', 'osf.io'] );
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
to track cross domain traffic between osf.io, openscienceframework.io, and centerforopenscience.org. Should fix minor tracking issues.
